### PR TITLE
Fix optional extras from dependencies being included by default

### DIFF
--- a/licensecheck/get_deps.py
+++ b/licensecheck/get_deps.py
@@ -163,7 +163,7 @@ def _doGetReqs(
 			)
 			response = request.json()
 			try:
-				for dependency in response["info"]["requires_dist"]:
+				for dependency in response["info"]["requires_dist"] or []:
 					update_dependencies(dependency)
 			except (KeyError, TypeError):
 				pass

--- a/licensecheck/get_deps.py
+++ b/licensecheck/get_deps.py
@@ -71,7 +71,10 @@ def _doGetReqs(
 		canonicalName = name
 		if len(extras) > 0:
 			canonicalName = ucstr(f"{name}[{list(extras)[0]}]")
-			extrasReqs[name] = extras
+			# To avoid overwriting the initial mapping in extrasReqs
+			# only overwrite when extra = True
+			if extra:
+				extrasReqs[name] = extras
 		return canonicalName if extra else name
 
 	def resolveExtraReq(extraReq: str) -> ucstr | None:
@@ -138,11 +141,22 @@ def _doGetReqs(
 
 	# Get Dependencies (1 deep)
 	requirementsWithDeps = reqs.copy()
+
+	def update_dependencies(dependency: str) -> None:
+		dep = resolveReq(dependency, False)  #
+		req = resolveReq(requirement, False)  # httpx
+		extra = resolveExtraReq(dependency)
+		if extra is not None:
+			if req in extrasReqs and extra in extrasReqs.get(req, []):
+				requirementsWithDeps.add(dep)
+		else:
+			requirementsWithDeps.add(dep)
+
 	for requirement in reqs:
 		try:
 			pkgMetadata = metadata.metadata(requirement)
-			for req in [resolveReq(req) for req in pkgMetadata.get_all("Requires-Dist") or []]:
-				requirementsWithDeps.add(req)
+			for dependency in pkgMetadata.get_all("Require-Dist") or []:
+				update_dependencies(dependency)
 		except metadata.PackageNotFoundError:
 			request = session.get(
 				f"https://pypi.org/pypi/{requirement.split('[')[0]}/json", timeout=60
@@ -150,15 +164,7 @@ def _doGetReqs(
 			response = request.json()
 			try:
 				for dependency in response["info"]["requires_dist"]:
-					dep = resolveReq(dependency, False)
-					req = resolveReq(requirement, False)
-					extra = resolveExtraReq(dependency)
-					if extra is not None:
-						if req in extrasReqs and extra in extrasReqs.get(req, []):
-							requirementsWithDeps.add(dep)
-						# else: pass
-					else:
-						requirementsWithDeps.add(dep)
+					update_dependencies(dependency)
 			except (KeyError, TypeError):
 				pass
 

--- a/licensecheck/get_deps.py
+++ b/licensecheck/get_deps.py
@@ -143,8 +143,8 @@ def _doGetReqs(
 	requirementsWithDeps = reqs.copy()
 
 	def update_dependencies(dependency: str) -> None:
-		dep = resolveReq(dependency, False)  #
-		req = resolveReq(requirement, False)  # httpx
+		dep = resolveReq(dependency, False)
+		req = resolveReq(requirement, False)
 		extra = resolveExtraReq(dependency)
 		if extra is not None:
 			if req in extrasReqs and extra in extrasReqs.get(req, []):


### PR DESCRIPTION
Hope to fix the following:
- Additional extras from downstream dependencies such as `dev`, `test`, etc were not being filtered out resulting in packages such as `pytest`, `PyQt` and other optional extras of dependencies always being included by default.
- More than one extras specified for downstream dependencies were being ignored e.g. `httpx[brotli,cli,socks]`.